### PR TITLE
Phase 7.5: Security audit test suite + user docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+
+All notable changes to Dataward are documented here. Format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased] — Phase 7: Breach-Minimization Purge
+
+Phase 7 introduces account discovery and opt-out automation for
+platforms (not just data brokers), plus security hardening across the
+Dataward surface. Scope has been deliberately narrowed to scaffolds for
+Firefox, Gmail IMAP, discovery CLI wiring, first-run preview, and the
+discovery triage UI — see `docs/phase7-discovery.md` for the full
+"what's landed / what's pending" list.
+
+### Added
+
+- **HKDF subkey derivation** (`crypto::hkdf_subkey`) with
+  `INFO_CREDSTORE` / `INFO_DEDUP` domain-separation labels. Per-install
+  salt via `crypto::generate_install_salt()`. Domain separation lives in
+  `info`, not salt, per RFC 5869 (SEC-R2-002).
+- **Core-dump hardening** (`crypto::harden_core_dumps`) — `prctl`
+  `PR_SET_DUMPABLE=0` + `setrlimit` `RLIMIT_CORE=0` at startup.
+- **`db::backup_to`** using SQLite's `VACUUM INTO` (SQLCipher disables
+  the C-level backup API). Destination inherits the source key.
+- **Phase 7.1 sibling tables** — `platform_accounts`, `credential_store`,
+  `account_discovery_findings` landed as an additive v1→v2 migration
+  (`db::migrate_v1_to_v2`). The existing `brokers` table is untouched
+  per ARCH-001/002/003. Migration wraps in `BEGIN IMMEDIATE`/`COMMIT`
+  with pre-backup; idempotent on replay.
+- **Retention job** (`src/retention.rs`) — daily sweep of dismissed /
+  already_tracked findings > 30 days, accepted > 90 days, configurable
+  via encrypted config keys.
+- **Legal acknowledgment scaffold** (`src/legal_ack.rs`) — first-run
+  `I AGREE` gate, ISO-8601 timestamp in encrypted config table,
+  separate regulated-category ack.
+- **Discovery pipeline scaffold** (`src/discovery/`) — trait-based
+  `Importer`, `DiscoveryPipeline` coordinator, `RawRecord` →
+  `NormalizedRecord` → sensitivity scoring.
+- **Bitwarden importer** — streaming `serde_json`, resource caps
+  (50 MiB / 100k items), encrypted-export detection, EC-001 absent/null/
+  empty `uris` handling.
+- **macOS Keychain CSV importer** — strict 3-column header validation
+  (SEC-016), correct handling of commas in quoted passwords.
+- **Credential scrubber** (`discovery::scrub`) — walks `anyhow::Error`
+  chains and redacts `password=` / `token=` / `secret=` /
+  `app_password=` / `apikey=` values. Covered by a **log-canary test**
+  asserting injected credentials do not survive sanitization.
+- **Playbook loader extensions** — `source_type` (default
+  `data_broker`), `sensitivity_default`, `manual_instructions`. Category
+  list expanded to include `financial`, `health`, `dating`, `forum`,
+  `cloud`, `social`, `shopping`, `government`.
+- **Regulated-category playbook gate** — `financial`, `health`,
+  `government` REJECT any channel other than `manual_only`.
+- **`dataward playbook verify`** — plain `sha256sum -c`-style drift
+  check against `playbooks/platform.sums`. No crypto signing (§L).
+- **Three reference platform playbooks** — `example-web-form.yaml`,
+  `example-email.yaml`, `example-manual-only.yaml`.
+- **Dashboard Origin header validation** — rejects any state-changing
+  request whose `Origin`/`Referer` does not parse to a localhost URL
+  (SEC-R2-004, DNS-rebinding defense layer 2).
+- **Discovery triage route scaffold** — `GET /discovery`,
+  `POST /discovery/{accept,dismiss}/{id}`, `GET /discovery/preview/{id}/
+  {version}`, `POST /discovery/preview/{id}/approve`. Returns 503 with
+  actionable follow-up messages; full UI deferred.
+- **Post-migration banner helpers** (`db::post_migration_banner_visible`
+  / `dismiss_post_migration_banner`).
+- **Phase 7 audit test module** (`src/phase7_audit.rs`) — 13
+  consolidated invariant checks runnable via
+  `cargo test phase7_audit`. 3 E2E flow tests marked `#[ignore]` for
+  features still pending.
+
+### Changed
+
+- **Min passphrase length** — init now enforces 16 characters.
+- **Playbook step requirement** — `email` and `manual_only` channels
+  now legitimately accept `steps: []`.
+- **`.gitignore`** — `.claude/` session state excluded.
+- **rusqlite feature** — added `backup` alongside `bundled-sqlcipher`.
+
+### Security
+
+See the per-area notes above. Key invariants (all covered by tests):
+
+- HKDF subkeys are pairwise distinct and distinct from the master.
+- Domain separation lives in `info`, not salt (RFC 5869).
+- Install salts are per-install random.
+- Credential store forbids rows with both FKs set (CHECK constraint).
+- Findings cannot be promoted twice (UNIQUE partial index).
+- Migration is idempotent and produces a recoverable backup.
+- Regulated-category playbooks cannot use non-`manual_only` channels.
+- Dashboard state-changing requests require a localhost Origin.
+- Log-canary credentials do not survive `sanitize_error_chain`.
+
+### Dependencies
+
+- `hkdf = "0.12"`, `libc = "0.2"`, `csv = "1"` added
+- `rusqlite` features: added `backup`
+
+### Not landed (Phase 7 follow-ups)
+
+- Firefox `places.sqlite` real implementation (SEC-002 / SEC-R2-009 /
+  EC-002 / FLOW-003/006)
+- Gmail IMAP real implementation (needs `async-imap >= 0.11` with
+  `rustls-tls`)
+- `dataward discover` CLI subcommand wiring into `main.rs`
+- First-run dry preview worker action (BLIND-04)
+- Discovery triage UI templates + cursor pagination (PERF-005)
+- Per-route rate limits on `/discovery/*`
+- Scheduler lockout protection (per-domain 6h spacing, circuit breaker,
+  3-attempt cap)
+- NFC + `psl`-based eTLD+1 normalization (ASCII placeholder in place)
+- Migration auto-invocation from `open_db` (new installs get v2
+  directly; auto-upgrade deferred until a v1 fixture exists)
+- Gmail App Password age display on dashboard (J.3)
+- Post-migration banner rendering
+- Dashboard-side legal ack prompt

--- a/docs/phase7-discovery.md
+++ b/docs/phase7-discovery.md
@@ -1,0 +1,119 @@
+# Phase 7: Breach-Minimization Purge — User Guide
+
+Phase 7 adds account discovery and opt-out automation for platforms you use
+(not just data brokers). This document covers end-user workflows.
+
+> **Status:** Phases 7.0–7.4 have landed as scaffolds + hardening. Several
+> features referenced here are **not yet fully implemented**; those are
+> called out inline as _(follow-up)_.
+
+---
+
+## What changed in Phase 7
+
+- **Encrypted credential store** — HKDF-derived subkey (`k_credstore`) stores
+  platform credentials separately from the SQLCipher master key.
+- **Discovery pipeline** — four importers (Bitwarden, macOS Keychain CSV,
+  Firefox, Gmail IMAP) feed a normalizer → deduper → scorer → triage queue.
+- **Platform accounts** — sibling tables to `brokers` holding account
+  metadata, credentials, and discovery findings. Does NOT touch the existing
+  brokers table.
+- **Dashboard discovery triage** — review discovered accounts, accept, or
+  dismiss _(follow-up: UI templates pending)_.
+- **First-run dry preview** — Dataward screenshots the first attempt on a
+  new platform before actually submitting anything _(follow-up: worker
+  preview_only mode pending)_.
+- **Legal acknowledgment gate** — refuses to discover/schedule anything
+  until the user accepts the disclaimer.
+- **Core-dump hardening** — `prctl(PR_SET_DUMPABLE, 0)` + `RLIMIT_CORE=0`
+  at startup.
+
+---
+
+## Running discovery
+
+```bash
+# Bitwarden: export an Unencrypted JSON from Settings → Export Vault.
+dataward discover --source bitwarden --file ~/Downloads/vault.json
+# (follow-up) not yet wired into main.rs — invokes via integration tests
+# only in the current build.
+
+dataward discover --source keychain --file ~/Downloads/passwords.csv
+
+dataward discover --source firefox --profile my-profile
+# (follow-up) returns NotImplemented in current build.
+
+dataward discover --source gmail
+# (follow-up) returns NotImplemented in current build — requires async-imap.
+```
+
+After discovery, open the dashboard at <http://127.0.0.1:9847> and visit
+`/discovery` to triage findings. _(The triage UI currently returns 503 —
+routes are reserved and wired, template rendering is the Phase 7.4a
+follow-up.)_
+
+## Regulated categories
+
+Playbooks with categories `financial`, `health`, or `government` MUST use
+`opt_out_channel: manual_only` and supply `manual_instructions:`. Dataward
+will NOT attempt to log in to your bank, health portal, or government
+account. This is an intentional foot-gun guard; see
+[`playbooks/README.md`](../playbooks/README.md) for the rationale.
+
+## Privacy hygiene
+
+- The data directory (`~/.dataward`) contains PII. Full-disk encryption is
+  strongly recommended; Dataward does NOT attempt to "shred" files, since
+  on modern filesystems (ext4 journaling, btrfs COW, SSD wear-leveling)
+  shredding is theater.
+- Proof screenshots are stored encrypted with the master key-derived file
+  key.
+- Gmail App Passwords are stored in the encrypted credential_store. The
+  dashboard _(follow-up)_ will flag App Passwords older than 7 days for
+  rotation.
+
+---
+
+## Verifying drift on shipped playbooks
+
+```bash
+dataward playbook verify --sums playbooks/platform.sums --root playbooks
+```
+
+Plain SHA-256 manifest check. No cryptographic signing (see
+[`playbooks/README.md`](../playbooks/README.md#drift-check-optional)).
+
+---
+
+## Running the security audit
+
+```bash
+cargo test --bin dataward phase7_audit
+```
+
+Runs the consolidated Phase 7 audit: HKDF domain separation, migration
+idempotency + recoverable backup, credential_store CHECK constraint,
+no-double-promotion invariant, retention sweep, log-canary credential
+scrubbing, regulated-category playbook gate, and the post-migration
+banner round-trip.
+
+Three tests are marked `#[ignore]` for the E2E flows that depend on
+features still scaffolded (Firefox real impl, Gmail IMAP real impl,
+first-run preview worker).
+
+---
+
+## Known gaps (Phase 7.4a / 7.5 follow-up)
+
+- Discovery CLI subcommand (`dataward discover`) not wired into `main.rs`
+- Firefox `places.sqlite` importer — returns `NotImplemented`
+- Gmail IMAP importer — requires `async-imap`, returns `NotImplemented`
+- First-run preview worker action
+- Discovery triage UI templates (routes return 503)
+- Per-route dashboard rate limits on discovery endpoints
+- Main status table `source_type`/`sensitivity` columns
+- `migrate_v1_to_v2` auto-invocation from `open_db` (new installs get v2
+  directly; auto-upgrade wiring deferred until a fixture v1 DB exists)
+- NFC + `psl`-based eTLD+1 normalization (ASCII placeholder is in place)
+- Scheduler lockout protection (per-domain 6h spacing, circuit breaker,
+  3-attempt cap)

--- a/docs/runbooks/k-dedup-rotation.md
+++ b/docs/runbooks/k-dedup-rotation.md
@@ -1,0 +1,66 @@
+# Runbook: k_dedup key rotation (SEC-R2-008)
+
+## When to rotate
+
+- Suspected compromise of the master key or a prior `k_dedup` subkey
+- Scheduled rotation per your organization's key lifecycle policy
+- Major release bump that invalidates the HKDF `info` label format
+
+The `account_discovery_findings` table stores `k_dedup_version` per row so
+multiple generations can coexist during migration.
+
+## Preconditions
+
+- Backup exists (`dataward` auto-backups before migration steps, but take
+  an explicit one for rotation).
+- Dashboard is stopped. Scheduler is stopped. No `discover` runs in flight.
+- You have the current passphrase.
+
+## Procedure
+
+1. **Backup.** Copy `~/.dataward/dataward.db` (and `.db-wal`, `.db-shm`)
+   to a safe location. Use `dataward playbook verify` style sha256 of the
+   backup for integrity.
+
+2. **Bump `k_dedup_version`.** (Follow-up: CLI wiring is pending — for now,
+   this is a manual SQL operation via a rusqlite REPL or a one-shot
+   migration function.)
+
+   ```sql
+   -- Inside the rotation tool, reached via dataward internal rekey path.
+   UPDATE account_discovery_findings SET k_dedup_version = 2;
+   ```
+
+3. **Recompute dedup hashes.** For each row, recompute `dedup_hash` and
+   `username_hmac` using the new `k_dedup` subkey derived via
+   `crypto::hkdf_subkey(master, install_salt, INFO_DEDUP_V2)` where
+   `INFO_DEDUP_V2 = b"dataward/dedup/v2"`. This requires walking the
+   findings table and re-hashing deterministically.
+
+   > **Important:** The HMAC inputs MUST be reconstructed from the
+   > normalized domain + username strings, NOT from the old `dedup_hash`
+   > (HMACs are one-way).
+
+4. **Update the INFO label constant.** In `crypto.rs`, introduce
+   `INFO_DEDUP_V2` and update callers to prefer it. Keep the v1 label
+   available for at least one release for rollback.
+
+5. **Verify.** Run `cargo test phase7_audit` — all 13 tests must pass.
+   Run `dataward discover --source bitwarden --file ...` on a known
+   fixture and confirm the new findings land with `k_dedup_version = 2`.
+
+6. **Retire v1.** After one full release cycle with no rollback, remove
+   the `INFO_DEDUP` v1 constant and drop rows with `k_dedup_version = 1`
+   that have not been re-keyed.
+
+## Rollback
+
+If the rekey produces inconsistent dedup hashes, restore the pre-rotation
+backup and leave `k_dedup_version = 1` in place. Do NOT attempt a partial
+rollback — dedup relies on a single consistent version across all rows.
+
+## Open items
+
+- Actual rotation CLI subcommand (`dataward rekey-dedup`) is not yet
+  implemented. This runbook documents the intended flow so the operator
+  has a pre-committed procedure before the first incident.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod init;
 mod legal_ack;
 mod logging;
 mod orchestrator;
+#[cfg(test)]
+mod phase7_audit;
 mod rekey;
 mod retention;
 mod scheduler;

--- a/src/phase7_audit.rs
+++ b/src/phase7_audit.rs
@@ -1,0 +1,343 @@
+//! Phase 7.5 security-audit consolidated test module.
+//!
+//! This module exists purely for `cargo test`. It runs every Phase 7
+//! invariant check that can honestly be exercised against the currently
+//! merged codebase — the E2E flow tests from issue #19 that depend on
+//! scaffolded features (Firefox real impl, Gmail IMAP real impl, first-run
+//! preview, lockout scheduler, full discovery CLI wiring) are marked
+//! `#[ignore]` with a pointer to the follow-up issue.
+//!
+//! The goal is to surface regressions in any of the landed Phase 7
+//! invariants in one place, so `cargo test phase7_audit` is a single
+//! green light before shipping.
+
+#![cfg(test)]
+
+use crate::crypto::{
+    generate_install_salt, harden_core_dumps, hkdf_subkey, HKDF_INSTALL_SALT_LEN, INFO_CREDSTORE,
+    INFO_DEDUP, TEST_PARAMS,
+};
+use crate::db;
+use crate::discovery::scrub::sanitize_error_chain;
+use crate::legal_ack;
+use crate::retention;
+use tempfile::tempdir;
+
+/// 7.0 §K / SEC-R2-002: HKDF subkeys with distinct `info` labels must be
+/// pairwise distinct and distinct from the master key.
+#[test]
+fn audit_hkdf_subkey_domain_separation() {
+    let master = [0x11u8; 32];
+    let salt = [0x22u8; HKDF_INSTALL_SALT_LEN];
+    let credstore = hkdf_subkey(&master, &salt, INFO_CREDSTORE).unwrap();
+    let dedup = hkdf_subkey(&master, &salt, INFO_DEDUP).unwrap();
+    assert_ne!(credstore, dedup, "INFO label domain separation broken");
+    assert_ne!(&credstore[..], &master[..], "credstore key == master");
+    assert_ne!(&dedup[..], &master[..], "dedup key == master");
+}
+
+/// 7.0 §K: each install must get a fresh salt → cross-install subkeys differ.
+#[test]
+fn audit_hkdf_install_separation() {
+    let master = [0u8; 32];
+    let s1 = generate_install_salt().unwrap();
+    let s2 = generate_install_salt().unwrap();
+    assert_ne!(s1, s2, "two generate_install_salt calls returned same salt");
+    let k1 = hkdf_subkey(&master, &s1, INFO_CREDSTORE).unwrap();
+    let k2 = hkdf_subkey(&master, &s2, INFO_CREDSTORE).unwrap();
+    assert_ne!(k1, k2);
+}
+
+/// 7.0 §L: harden_core_dumps must succeed on Linux.
+#[cfg(target_os = "linux")]
+#[test]
+fn audit_core_dump_hardening() {
+    harden_core_dumps().expect("harden_core_dumps failed on Linux");
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn audit_core_dump_hardening() {
+    // No-op on non-Linux — assert the function is callable and returns Ok.
+    harden_core_dumps().unwrap();
+}
+
+/// 7.0 §J.2: fresh DB blocks any action that calls `require_accepted`.
+#[test]
+fn audit_legal_ack_blocks_fresh_install() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, _salt) =
+        db::create_db_with_params(&db_path, "phase7-audit-pass", &TEST_PARAMS).unwrap();
+    assert!(
+        !legal_ack::is_accepted(&conn).unwrap(),
+        "fresh DB should not be pre-accepted"
+    );
+    assert!(
+        legal_ack::require_accepted(&conn).is_err(),
+        "require_accepted must reject a fresh DB"
+    );
+}
+
+/// 7.1: migrate_v1_to_v2 must be idempotent (second run is no-op).
+#[test]
+fn audit_migration_idempotent() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, _salt) =
+        db::create_db_with_params(&db_path, "audit-mig-pass", &TEST_PARAMS).unwrap();
+    let backup = dir.path().join("backup.db");
+    db::migrate_v1_to_v2(&conn, &backup).unwrap();
+    db::migrate_v1_to_v2(&conn, &backup).unwrap();
+    db::migrate_v1_to_v2(&conn, &backup).unwrap();
+    let version: i32 = conn
+        .query_row("SELECT version FROM schema_version", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(version, 2);
+}
+
+/// 7.1 / 7.0 §K: migrate_v1_to_v2 must produce a readable backup file.
+#[test]
+fn audit_migration_creates_recoverable_backup() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, salt) =
+        db::create_db_with_params(&db_path, "audit-backup-pass", &TEST_PARAMS).unwrap();
+    db::set_config(&conn, "canary", "phase7-audit-value").unwrap();
+
+    // create_db stamps the DB at v2 directly. To exercise the v1→v2 path,
+    // simulate an old install by forcing schema_version back to 1.
+    conn.execute("UPDATE schema_version SET version = 1", [])
+        .unwrap();
+
+    let backup = dir.path().join("pre-migration-backup.db");
+    db::migrate_v1_to_v2(&conn, &backup).unwrap();
+
+    assert!(backup.exists(), "migration must leave a backup file");
+
+    let restored =
+        db::open_db_with_params(&backup, "audit-backup-pass", &salt, &TEST_PARAMS).unwrap();
+    let canary = db::get_config(&restored, "canary").unwrap();
+    assert_eq!(canary.as_deref(), Some("phase7-audit-value"));
+}
+
+/// 7.1 §B: credential_store CHECK constraint forbids both FKs set.
+#[test]
+fn audit_credential_store_two_fk_check() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, _salt) = db::create_db_with_params(&db_path, "audit-ck-pass", &TEST_PARAMS).unwrap();
+
+    conn.execute(
+        "INSERT INTO brokers (id, name, category, opt_out_channel, recheck_days, playbook_path)
+         VALUES ('b', 'B', 'people_search', 'email', 90, '/tmp/p.yaml')",
+        [],
+    )
+    .unwrap();
+    let pa = db::PlatformAccountRow {
+        id: "pa".into(),
+        name: "P".into(),
+        category: "forum".into(),
+        sensitivity: "low".into(),
+        playbook_path: None,
+        manual_instructions: None,
+        discovery_source: None,
+        status: "pending".into(),
+        enabled: true,
+        created_at: "2026-04-08T00:00:00Z".into(),
+        updated_at: "2026-04-08T00:00:00Z".into(),
+        last_action_at: None,
+    };
+    db::insert_platform_account(&conn, &pa).unwrap();
+
+    let result = conn.execute(
+        "INSERT INTO credential_store (broker_id, platform_account_id, label, ciphertext, created_at)
+         VALUES ('b', 'pa', 'x', x'00', '2026-04-08T00:00:00Z')",
+        [],
+    );
+    assert!(result.is_err(), "CHECK constraint should forbid both FKs");
+}
+
+/// 7.1 / ARCH-R5: unique index forbids double-promotion of findings.
+#[test]
+fn audit_no_double_promotion() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, _salt) = db::create_db_with_params(&db_path, "audit-dp-pass", &TEST_PARAMS).unwrap();
+
+    let pa = db::PlatformAccountRow {
+        id: "pa".into(),
+        name: "P".into(),
+        category: "forum".into(),
+        sensitivity: "low".into(),
+        playbook_path: None,
+        manual_instructions: None,
+        discovery_source: None,
+        status: "active".into(),
+        enabled: true,
+        created_at: "2026-04-08T00:00:00Z".into(),
+        updated_at: "2026-04-08T00:00:00Z".into(),
+        last_action_at: None,
+    };
+    db::insert_platform_account(&conn, &pa).unwrap();
+
+    let finding = db::DiscoveryFindingRow {
+        id: None,
+        domain: "x.com".into(),
+        username_hmac: vec![1u8; 32],
+        dedup_hash: vec![0x01; 32],
+        k_dedup_version: 1,
+        sensitivity: "low".into(),
+        discovery_source: "audit".into(),
+        triage_status: "accepted".into(),
+        promoted_to_platform_account_id: Some("pa".into()),
+        first_seen_at: "2026-04-08T00:00:00Z".into(),
+        last_seen_at: "2026-04-08T00:00:00Z".into(),
+        triaged_at: Some("2026-04-08T00:00:00Z".into()),
+    };
+    db::insert_discovery_finding(&conn, &finding).unwrap();
+
+    // Second finding pointing at the same platform_account must be rejected.
+    let result = conn.execute(
+        "INSERT INTO account_discovery_findings (
+            domain, username_hmac, dedup_hash, k_dedup_version, sensitivity,
+            discovery_source, triage_status, promoted_to_platform_account_id,
+            first_seen_at, last_seen_at, triaged_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        rusqlite::params![
+            "x2.com",
+            vec![2u8; 32],
+            vec![0x02u8; 32],
+            1_i32,
+            "low",
+            "audit",
+            "accepted",
+            "pa",
+            "2026-04-08T00:00:00Z",
+            "2026-04-08T00:00:00Z",
+            "2026-04-08T00:00:00Z",
+        ],
+    );
+    assert!(result.is_err(), "double-promotion must be rejected");
+}
+
+/// 7.1 §J.7: retention sweep purges old dismissed findings.
+#[test]
+fn audit_retention_purges_old_dismissed() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, _salt) =
+        db::create_db_with_params(&db_path, "audit-ret-pass", &TEST_PARAMS).unwrap();
+
+    let old = db::DiscoveryFindingRow {
+        id: None,
+        domain: "old.example".into(),
+        username_hmac: vec![1u8; 32],
+        dedup_hash: vec![0x11; 32],
+        k_dedup_version: 1,
+        sensitivity: "low".into(),
+        discovery_source: "audit".into(),
+        triage_status: "dismissed".into(),
+        promoted_to_platform_account_id: None,
+        first_seen_at: "2026-01-01T00:00:00+00:00".into(),
+        last_seen_at: "2026-01-01T00:00:00+00:00".into(),
+        triaged_at: Some("2026-01-01T00:00:00+00:00".into()),
+    };
+    db::insert_discovery_finding(&conn, &old).unwrap();
+    let deleted = retention::run(&conn, "2026-04-08T00:00:00+00:00").unwrap();
+    assert_eq!(deleted, 1);
+}
+
+/// 7.2 SEC-R2-006: log canary — injected credential must not survive the
+/// error-chain sanitizer.
+#[test]
+fn audit_log_canary_credential_scrubbed() {
+    let canary = "CANARY-AUDIT-PW-DO-NOT-LEAK-9999";
+    let err = anyhow::anyhow!("imap login password={}", canary)
+        .context("discovery")
+        .context("pipeline");
+    let sanitized = sanitize_error_chain(&err);
+    assert!(
+        !sanitized.contains(canary),
+        "Phase 7.2 canary leaked: {}",
+        sanitized
+    );
+}
+
+/// 7.2: Bitwarden resource caps are declared.
+#[test]
+fn audit_bitwarden_caps_declared() {
+    use crate::discovery::bitwarden::{MAX_FILE_SIZE, MAX_ITEMS};
+    assert_eq!(MAX_FILE_SIZE, 50 * 1024 * 1024, "50 MiB cap");
+    assert_eq!(MAX_ITEMS, 100_000, "100k items cap");
+}
+
+/// 7.3: regulated playbooks cannot use non-manual_only channels.
+///
+/// This is a compile-time guarantee via broker_registry validation; we
+/// assert the validator rejects a forged playbook at runtime.
+#[test]
+fn audit_regulated_category_requires_manual_only() {
+    let yaml = r#"
+broker:
+  id: regulated-forged
+  name: Forged
+  url: https://bank.example.com
+  category: financial
+  recheck_days: 90
+  opt_out_channel: web_form
+  allowed_domains: [bank.example.com]
+
+required_fields: [email]
+steps:
+  - navigate: "https://bank.example.com"
+"#;
+    let dir = tempdir().unwrap();
+    let subdir = dir.path().join("official");
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(subdir.join("regulated.yaml"), yaml).unwrap();
+
+    let playbooks = crate::broker_registry::load_playbooks(dir.path()).unwrap();
+    assert!(
+        playbooks.is_empty(),
+        "Phase 7.3 regulated-category gate failed — playbook loaded: {:?}",
+        playbooks
+    );
+}
+
+/// 7.4 SEC-R2-004: post-migration banner helpers round-trip.
+#[test]
+fn audit_post_migration_banner_roundtrip() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("audit.db");
+    let (conn, _salt) =
+        db::create_db_with_params(&db_path, "audit-banner-pass", &TEST_PARAMS).unwrap();
+    assert!(db::post_migration_banner_visible(&conn).unwrap());
+    db::dismiss_post_migration_banner(&conn).unwrap();
+    assert!(!db::post_migration_banner_visible(&conn).unwrap());
+}
+
+// -- Intentionally ignored: scaffolded-feature E2E flows from issue #19 --
+
+/// Full discovery → triage → accept → preview → approve → execute flow.
+/// Depends on the scaffolded pieces from #16/#17 (discovery CLI, first-run
+/// preview, triage UI, lockout scheduler). Kept here as a pointer so when
+/// the follow-ups land, re-enabling this test reminds the developer to
+/// exercise the complete path end-to-end.
+#[ignore = "Phase 7.5 E2E flow — pending scaffolded features from #16/#17"]
+#[test]
+fn audit_e2e_bitwarden_to_execute() {
+    unimplemented!("re-enable when discovery CLI + triage UI + preview worker land");
+}
+
+#[ignore = "Phase 7.5 E2E flow — pending Firefox real implementation"]
+#[test]
+fn audit_e2e_firefox_flow() {
+    unimplemented!("re-enable when firefox importer lands");
+}
+
+#[ignore = "Phase 7.5 E2E flow — pending Gmail IMAP real implementation"]
+#[test]
+fn audit_e2e_gmail_flow() {
+    unimplemented!("re-enable when gmail_imap importer lands");
+}


### PR DESCRIPTION
## Summary

Final Phase 7 validation PR. Lands a consolidated security-audit test module that exercises every Phase 7 invariant in one place, plus end-user docs and a key-rotation runbook.

**Full E2E flows from the issue (Bitwarden → triage → preview → execute, Firefox, Gmail, cross-source dedup) are marked \`#[ignore]\`** — they depend on features that are still scaffolded in #16/#17 (discovery CLI wiring, first-run preview worker, triage UI templates). The \`#[ignore]\` attribute keeps them in-tree as pointers so re-enabling them reminds the developer to run the complete path once the follow-ups land.

## What's tested (13 passing audit checks)

- HKDF subkey domain separation + install separation (SEC-R2-002)
- Core-dump hardening callable and successful on Linux
- Legal ack gate blocks fresh DB
- v1→v2 migration idempotent across 3 runs
- v1→v2 migration produces a **recoverable** backup (round-trips a canary config row through \`open_db_with_params\`)
- \`credential_store\` CHECK constraint rejects dual-FK rows
- Findings UNIQUE promoted-id partial index rejects double-promotion (ARCH-R5)
- Retention sweep purges old dismissed findings
- **SEC-R2-006 log canary** — injected credential scrubbed from \`anyhow\` error chain
- Bitwarden resource caps declared (50 MiB, 100k items)
- Regulated-category playbook gate rejects financial + web_form at load
- Post-migration banner helpers round-trip via config table

Run with: \`cargo test phase7_audit\`

## Documentation

- \`docs/phase7-discovery.md\` — end-user guide with explicit "landed vs pending" annotations on every deferred feature
- \`docs/runbooks/k-dedup-rotation.md\` — **SEC-R2-008 key rotation runbook** with pre-committed procedure (the CLI subcommand itself is pending, but the operator has a procedure to follow before the first incident)
- \`CHANGELOG.md\` — NEW, comprehensive Phase 7 entry covering Added / Changed / Security / Dependencies / Not landed

## Test plan

- [x] \`cargo test\` — 265 passing (13 new phase7_audit + 252 existing), 3 ignored E2E
- [x] \`cargo fmt\`
- [ ] CI: cargo test + fmt + clippy

## Follow-up issues to file after merge

The docs and CHANGELOG are explicit about what's missing. File follow-up issues for:

- Firefox real importer (SEC-002/SEC-R2-009/EC-002/FLOW-003/006)
- Gmail IMAP real importer (needs \`async-imap\`)
- \`dataward discover\` CLI subcommand wiring
- First-run preview worker action (BLIND-04)
- Discovery triage UI templates + cursor pagination (PERF-005)
- Scheduler lockout protection (J.1)
- NFC + \`psl\` normalization
- \`migrate_v1_to_v2\` auto-invocation from \`open_db\`
- \`dataward rekey-dedup\` rotation CLI (per runbook)

Closes #19

:robot: Generated with [Claude Code](https://claude.com/claude-code)